### PR TITLE
Make sure to do a rollback in case of errors in wrap_finish()

### DIFF
--- a/query_wrapper.sql
+++ b/query_wrapper.sql
@@ -150,6 +150,7 @@ CREATE OR REPLACE LUA SCRIPT etl.query_wrapper () RETURNS ROWCOUNT AS
             main_state = 'FINISHED SUCCESSFULLY'
             if self.errors > 0 then
                 main_state = 'FINISHED WITH ERROR'
+                self:rollback()
             end
 
             -- TODO: should use self:query()


### PR DESCRIPTION
While integrating the query wrapper into one of our loading scripts, I noticed as I was testing the outcome that even if a `wrapper:query(...)` call failed, and aborted the script, previous database updates within the same script would still be committed.

This happens because `wrap_query`, in case of an error and where `self.on_error == 'abort'`, calls `self:finish()`, which in the default implementation proceeds to just write the log entries and do a `self:commit()`.

As this was somewhat surprising to me, I felt that perhaps `wrap_finish` should do a rollback before writing the log entries if there were any errors.

If one doesn't want a rollback to happen in case of errors, it's easy enough to set `self.on_error` to something else than abort, and handle errors manually.

Alternatively, one can also do some checkpointing by just calling `wrapper:commit()` at well-chosen places throughout a script, if there are partial changes that *should* be preserved.