### PR TITLE
Show real error instead of 'number of open resultsets exceeds 250' in some cases.

### DIFF
--- a/query_wrapper.sql
+++ b/query_wrapper.sql
@@ -260,8 +260,8 @@ CREATE OR REPLACE LUA SCRIPT etl.query_wrapper () RETURNS ROWCOUNT AS
         )
 
         if not success then
-            self:log( 'WARNING', 'Failed to register job for persistent logging: [' .. res.error_code .. '] ' .. res.error_message )
-            return nil
+            -- self:log( 'WARNING', 'Failed to register job for persistent logging: [' .. res.error_code .. '] ' .. res.error_message )
+            error('[querywrapper] get_unique_run_id() failed to register job for persistent logging [' .. res.error_code .. '] ' .. res.error_message )
         end
 
         -- Step 2) retrieve max ELT_RUN_ID


### PR DESCRIPTION
Sometimes in case of problems with writing to log table(s) a not very transparent error message is shown:
"pquery function: number of open resultsets exceeds 250".
The reason is in recursion of the form "log the fact that I could not write to the logs".
With the change a more descriptive error message will be thrown at the moment when something goes wrong.